### PR TITLE
fix: path alias @ and lint rule override @typescript-eslint/no-empty-interface 

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -55,7 +55,11 @@ const config = {
           "ctx.db"
         ]
       }
-    ]
+    ],
+    '@typescript-eslint/no-empty-interface': [
+      'error',
+      { allowSingleExtends: true },
+    ],
   }
 }
 module.exports = config;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import { set } from "zod";
-import { Button } from "../components/ui/button.tsx";
-import { Textarea } from "../components/ui/textarea.tsx";
+import { Button } from "@/components/ui/button.tsx";
+import { Textarea } from "@/components/ui/textarea.tsx";
 import Link from "next/link"
 import { useState } from "react"; 
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "lib": ["dom", "dom.iterable", "ES2022"],
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "node",
+    "moduleResolution": "Node10",
     "jsx": "preserve",
     "plugins": [{ "name": "next" }],
     "incremental": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "lib": ["dom", "dom.iterable", "ES2022"],
     "noEmit": true,
     "module": "ESNext",
-    "moduleResolution": "Node10",
+    "moduleResolution": "Bundler",
     "jsx": "preserve",
     "plugins": [{ "name": "next" }],
     "incremental": true,
@@ -27,7 +27,8 @@
     /* Path Aliases */
     "baseUrl": ".",
     "paths": {
-      "~/*": ["./src/*"]
+      "~/*": ["./src/*"],
+      "@/*": ["./src/*"],
     }
   },
   "include": [


### PR DESCRIPTION
### This PR fixes 1) module resolution error and 2) TS lint rule error in vercel deployment

### Description

- add path alias @ to avoid `../..` snake while using relative imports for shadcn-ui components
  - refer https://dev.to/larswaechter/path-aliases-with-typescript-in-nodejs-4353
- ignore @typescript-eslint/no-empty-interface rule 
  - issue to be fixed: https://github.com/shadcn-ui/ui/issues/167#issuecomment-1663169959